### PR TITLE
Implementación de lista de alquileres disponibles, filtros y mis garajes

### DIFF
--- a/src/app/components/rental/available-garages/available-garages.component.html
+++ b/src/app/components/rental/available-garages/available-garages.component.html
@@ -1,0 +1,31 @@
+<ion-grid>
+  <ion-row>
+    <ion-col size="12" size-md="4">
+      <ion-input [(ngModel)]="nameFilter" placeholder="Filtrar por nombre"></ion-input>
+    </ion-col>
+    <ion-col size="12" size-md="4">
+      <ion-input [(ngModel)]="priceFilter" placeholder="Filtrar por precio" type="number"></ion-input>
+    </ion-col>
+    <ion-col size="12" size-md="4">
+      <ion-input [(ngModel)]="dimensionFilter" placeholder="Filtrar por dimensiones" type="number"></ion-input>
+    </ion-col>
+  </ion-row>
+
+  <ion-row *ngFor="let garage of filteredGarages">
+    <ion-col size="12">
+      <ion-card>
+        <ion-card-header>
+          <ion-card-title><a [routerLink]="['/aparKing/garages', garage.id]">{{ garage.name }}</a></ion-card-title>
+          <ion-card-subtitle>{{ garage.description }}</ion-card-subtitle>
+        </ion-card-header>
+        <ion-card-content>
+          <p>Dimensiones: {{ garage.height }} x {{ garage.width }} x {{ garage.length }}</p>
+          <p>Precio: {{ garage.price }}</p>
+          <p>Día de subida: {{ garage.creation_date }}</p>
+          <p>Estado: {{ garage.is_active ? 'Active' : 'Inactive' }}</p>
+          <p>Propietario: {{ garage.owner }}</p>
+        </ion-card-content>
+      </ion-card>
+    </ion-col>
+  </ion-row>
+</ion-grid>

--- a/src/app/components/rental/available-garages/available-garages.component.scss
+++ b/src/app/components/rental/available-garages/available-garages.component.scss
@@ -1,0 +1,11 @@
+.garage-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  padding: 16px;
+}
+
+.garage-card {
+  max-width: 400px;
+  margin: 16px;
+}

--- a/src/app/components/rental/available-garages/available-garages.component.ts
+++ b/src/app/components/rental/available-garages/available-garages.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { Garage, Image } from 'src/app/models/garagement';
+import { RestService } from 'src/app/services/rest.service';
+
+@Component({
+  selector: 'app-available-garages',
+  templateUrl: './available-garages.component.html',
+  styleUrls: ['./available-garages.component.scss'],
+})
+export class AvailableGaragesComponent  implements OnInit {
+  garages!: any[];
+  garage: Garage[] = [];
+  nameFilter: string = '';
+  priceFilter!: number;
+  dimensionFilter!: number;
+
+  constructor(private restService: RestService) {}
+
+  ngOnInit(): void {
+    this.getAvailableGarages();
+  }
+
+  getAvailableGarages() {
+    this.restService.getAvailableGarages().then((garages) => {
+      this.garages = garages;
+      console.log(this.garages);
+    });
+  }
+
+  get filteredGarages() {
+    return this.garages.filter(garage =>
+      garage.name.toLowerCase().includes(this.nameFilter.toLowerCase()) &&
+      (!this.priceFilter || garage.price <= this.priceFilter) &&
+      (!this.dimensionFilter || Math.max(garage.height, garage.width, garage.length) <= this.dimensionFilter)
+    );
+  }
+}

--- a/src/app/components/rental/my-garages/my-garages.component.html
+++ b/src/app/components/rental/my-garages/my-garages.component.html
@@ -1,0 +1,19 @@
+<ion-grid>
+  <ion-row *ngFor="let garage of garages">
+    <ion-col size="12">
+      <ion-card>
+        <ion-card-header>
+          <ion-card-title><a [routerLink]="['/aparKing/my-garages', garage.id]">{{ garage.name }}</a></ion-card-title>
+          <ion-card-subtitle>{{ garage.description }}</ion-card-subtitle>
+        </ion-card-header>
+        <ion-card-content>
+          <p>Dimensiones: {{ garage.height }} x {{ garage.width }} x {{ garage.length }}</p>
+          <p>Precio: {{ garage.price }}</p>
+          <p>Día de subida: {{ garage.creation_date }}</p>
+          <p>Estado: {{ garage.is_active ? 'Active' : 'Inactive' }}</p>
+          <p>Propietario: {{ garage.owner }}</p>
+        </ion-card-content>
+      </ion-card>
+    </ion-col>
+  </ion-row>
+</ion-grid>

--- a/src/app/components/rental/my-garages/my-garages.component.scss
+++ b/src/app/components/rental/my-garages/my-garages.component.scss
@@ -1,0 +1,11 @@
+.garage-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  padding: 16px;
+}
+
+.garage-card {
+  max-width: 400px;
+  margin: 16px;
+}

--- a/src/app/components/rental/my-garages/my-garages.component.ts
+++ b/src/app/components/rental/my-garages/my-garages.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { Garage } from 'src/app/models/garagement';
+import { RestService } from 'src/app/services/rest.service';
+
+@Component({
+  selector: 'app-my-garages',
+  templateUrl: './my-garages.component.html',
+  styleUrls: ['./my-garages.component.scss'],
+})
+export class MyGaragesComponent  implements OnInit {
+  garages!: any[];
+  garage: Garage[] = [];
+
+  constructor(private restService: RestService) {}
+
+  ngOnInit(): void {
+    this.getMyGarages();
+  }
+
+  getMyGarages() {
+    this.restService.getMyGarages().then((garages) => {
+      this.garages = garages;
+      console.log(this.garages);
+    });
+  }
+
+}

--- a/src/app/services/rest.service.ts
+++ b/src/app/services/rest.service.ts
@@ -29,15 +29,27 @@ export class RestService extends WsAstractService {
   }
 
   async getAllImages(): Promise<Image[]> {
-    return await this.makeGetRequest(`${this.path}/garages/`);
+    return await this.makeGetRequest(`${this.path}/garages/images/`);
   }
 
   async getImage(id: string): Promise<any> {
-    return await this.makeGetRequest(`${this.path}/garages/`);
+    return await this.makeGetRequest(`${this.path}/garages/images/${id}`);
   }
 
   async getGarageById(id: string): Promise<any> {
     return await this.makeGetRequest(`${this.path}/garages/${id}`);
+  }
+
+  async getAvailableGarages(): Promise<Garage[]> {
+    return await this.makeGetRequest(`${this.path}/garages/available/`);
+  }
+
+  async getMyGarages(): Promise<Garage[]> {
+    return await this.makeGetRequest(`${this.path}/garages/mine/`);
+  }
+
+  async getMyAvailableGarages(): Promise<Garage[]> {
+    return await this.makeGetRequest(`${this.path}/garages/mine/available/`);
   }
 
   async createGarage(data: any): Promise<any> {

--- a/src/app/tab2/tab2.page.html
+++ b/src/app/tab2/tab2.page.html
@@ -1,9 +1,11 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
-    <ion-title> Listado de alquileres de garajes </ion-title>
+    <ion-title> Listado de alquileres disponibles </ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <app-garage-list> </app-garage-list>
+  <app-available-garages> </app-available-garages>
+  <ion-button expand="full" (click)="presentModal()">Lista de garajes admin</ion-button>
+  <ion-button expand="full" (click)="presentMyGaragesModal()">Mis alquileres</ion-button>
 </ion-content>

--- a/src/app/tab2/tab2.page.ts
+++ b/src/app/tab2/tab2.page.ts
@@ -1,4 +1,7 @@
 import { Component } from '@angular/core';
+import { ModalController } from '@ionic/angular';
+import { GarageListComponent } from '../components/rental/garage-list/garage-list.component';
+import { MyGaragesComponent } from '../components/rental/my-garages/my-garages.component';
 
 @Component({
   selector: 'app-tab2',
@@ -7,6 +10,20 @@ import { Component } from '@angular/core';
 })
 export class Tab2Page {
 
-  constructor() {}
+  constructor(private modalController: ModalController) { }
 
+  async presentModal() {
+    const modal = await this.modalController.create({
+      component: GarageListComponent
+    });
+    return await modal.present();
+  }
+
+  async presentMyGaragesModal() {
+    const modal = await this.modalController.create({
+      component: MyGaragesComponent,
+      cssClass: 'custom-modal'
+    });
+    return await modal.present();
+  }
 }

--- a/src/app/tabs/tabs.module.ts
+++ b/src/app/tabs/tabs.module.ts
@@ -9,6 +9,8 @@ import { TabsPageRoutingModule } from './tabs-routing.module';
 import { RouterModule } from '@angular/router';
 import { GarageDetailComponent } from '../components/rental/garage-detail/garage-detail.component';
 import { GarageListComponent } from '../components/rental/garage-list/garage-list.component';
+import { AvailableGaragesComponent } from '../components/rental/available-garages/available-garages.component';
+import { MyGaragesComponent } from '../components/rental/my-garages/my-garages.component';
 import { RestService } from '../services/rest.service';
 import { TabsPage } from './tabs.page';
 
@@ -21,8 +23,8 @@ import { TabsPage } from './tabs.page';
     HttpClientModule,
     RouterModule,
   ],
-  declarations: [TabsPage, GarageListComponent, GarageDetailComponent],
-  exports: [GarageListComponent, GarageDetailComponent],
+  declarations: [TabsPage, GarageListComponent, GarageDetailComponent, AvailableGaragesComponent, MyGaragesComponent],
+  exports: [GarageListComponent, GarageDetailComponent, AvailableGaragesComponent, MyGaragesComponent],
   providers: [RestService],
 })
 export class TabsPageModule {}


### PR DESCRIPTION
Tarea referenciada: https://github.com/Aparking/AparKing_Backend/issues/10
Realizada por: @silvglad 
Resumen: Se implementa dentro del Tab2 la vista de todos los alquileres disponibles de todos los usuarios. Dentro de la misma vista, hay tres tipos de filtros: por nombre, por precio y por dimensiones. La lista de alquileres se actualiza reactivamente con los filtros y la vista se ha adaptado a móviles.
En la misma vista, se implementan dos botones en la parte inferior: 
- La vista de todos los garajes para un admin, realizado por @laurolmer en https://github.com/Aparking/AparKing_Backend/issues/11 . Como aún no se ha implementado la autenticación ni el inicio de sesión en la aplicación, no se comprueban los permisos aún.
- La vista de los alquileres de un usuario. Ahora mismo, como el backend intenta buscar también tu usuario para devolverte los garajes, no se recibe nada al no tener implementada la autenticación aún como en el apartado anterior.
