### PR TITLE
Comprobar plan contratado a la hora de crear un garaje

### DIFF
--- a/src/app/components/rental/garage-list/garage-list.component.html
+++ b/src/app/components/rental/garage-list/garage-list.component.html
@@ -1,7 +1,6 @@
 <ion-grid>
   <ion-buttons>
     <ion-button
-      [routerLink]="'create'"
       color="danger"
       shape="round"
       size="small"

--- a/src/app/components/rental/garage-list/garage-list.component.ts
+++ b/src/app/components/rental/garage-list/garage-list.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { ModalController, NavController } from '@ionic/angular';
+import {
+  AlertController,
+  ModalController,
+  NavController,
+} from '@ionic/angular';
+import { MembershipType } from 'src/app/models/payments';
+import { DataManagementService } from 'src/app/service/data-management.service';
 import { GarageStateService } from 'src/app/service/garage-state.service';
 import { RestService } from 'src/app/service/rest.service';
 import { environment } from 'src/environments/environment';
@@ -13,6 +19,7 @@ import { GarageDetailComponent } from '../garage-detail/garage-detail.component'
 })
 export class GarageListComponent implements OnInit {
   component = GarageDetailComponent;
+  userInfo: any | null;
   garages: any[] = [];
   _filterTitle: string = '';
   _filterPriceMin: number = 0;
@@ -95,7 +102,9 @@ export class GarageListComponent implements OnInit {
     private restService: RestService,
     private modalCtrl: ModalController,
     private navCtrl: NavController,
-    private garageStateService: GarageStateService
+    private garageStateService: GarageStateService,
+    private dataManagementService: DataManagementService,
+    private alertController: AlertController
   ) {}
 
   ngOnInit() {
@@ -160,7 +169,51 @@ export class GarageListComponent implements OnInit {
     return await modal.present();
   }
 
-  navigateToCreateGarage() {
-    this.navCtrl.navigateForward('/G11/aparKing/garages/create');
+  async navigateToCreateGarage() {
+    await this.dataManagementService
+      .subscription()
+      .then((data) => {
+        this.userInfo = data.user_info;
+      })
+      .catch((_) => {
+        this.userInfo = null;
+      });
+
+    if (!this.userInfo) {
+      const alert = await this.alertController.create({
+        header: 'No puedes crear garajes',
+        message:
+          'Para poder crear garajes necesitas tener una suscripción activa',
+        buttons: ['OK'],
+      });
+      await alert.present();
+      return;
+    } else {
+      let myGarages = await this.restService
+        .getMyGarages()
+        .then((data) => {
+          return data.length;
+        })
+        .catch((_) => 0);
+
+      if (
+        (this.userInfo.membership.type === MembershipType.FREE &&
+          myGarages + 1 > 1) ||
+        (this.userInfo.membership.type === MembershipType.NOBLE &&
+          myGarages + 1 > 3) ||
+        (this.userInfo.membership.type === MembershipType.KING &&
+          myGarages + 1 > 5)
+      ) {
+        const alert = await this.alertController.create({
+          header: 'No puedes crear más garajes',
+          message:
+            'Has alcanzado el límite de garajes que puedes crear con tu suscripción',
+          buttons: ['OK'],
+        });
+        await alert.present();
+        return;
+      }
+      this.navCtrl.navigateForward('/G11/aparKing/garages/create');
+    }
   }
 }

--- a/src/app/components/subscription/subscription.component.ts
+++ b/src/app/components/subscription/subscription.component.ts
@@ -1,15 +1,20 @@
 import { Component, OnInit } from '@angular/core';
-import { NavController } from '@ionic/angular';
+import { AlertController, NavController } from '@ionic/angular';
 import { User } from 'src/app/models/authentication';
-import { CombinedDataPayment, Credit, Membership, Plan } from 'src/app/models/payments';
+import {
+  CombinedDataPayment,
+  Credit,
+  Membership,
+  Plan,
+} from 'src/app/models/payments';
 import { DataManagementService } from 'src/app/service/data-management.service';
 import { PaymentService } from 'src/app/service/payment.service';
-
+import { RestService } from 'src/app/service/rest.service';
 
 @Component({
   selector: 'app-subscription',
   templateUrl: './subscription.component.html',
-  styleUrls: ['./subscription.component.scss']
+  styleUrls: ['./subscription.component.scss'],
 })
 export class SubscriptionComponent implements OnInit {
   ngOnInit() {
@@ -21,27 +26,35 @@ export class SubscriptionComponent implements OnInit {
   path = this.serverUrl + this.apiPath;
 
   userInfo?: {
-    'user': User,
-    'membership': Membership,
-    'credit': Credit
+    user: User;
+    membership: Membership;
+    credit: Credit;
   };
   plans: Plan[] = [
     { id: 'FREE', name: 'FREE', price: '0€/month' },
     { id: 'NOBLE', name: 'NOBLE', price: '3.99€/month' },
-    { id: 'KING', name: 'KING', price: '4.99€/month' }
+    { id: 'KING', name: 'KING', price: '4.99€/month' },
   ];
 
-  constructor(private paymentService: PaymentService, private dataManagementService: DataManagementService, private navCtrl: NavController,) { }
-
-
+  constructor(
+    private paymentService: PaymentService,
+    private dataManagementService: DataManagementService,
+    private navCtrl: NavController,
+    private restService: RestService,
+    private alertController: AlertController
+  ) {}
 
   async selectPlan(planId: string) {
     try {
-      const session = await this.dataManagementService.createCheckoutSession(planId, this.path);
+      const session = await this.dataManagementService.createCheckoutSession(
+        planId,
+        this.path
+      );
       window.location.href = session.url;
     } catch (error) {
       console.error(error);
     }
+    await this.updateUserGaragesWithPlan(planId);
   }
 
   async getUserInfo() {
@@ -49,14 +62,59 @@ export class SubscriptionComponent implements OnInit {
       (response: { user_info: CombinedDataPayment }) => {
         this.userInfo = response.user_info;
       },
-      error => {
+      (error) => {
         console.error('Error al obtener la información del usuario', error);
-
       }
     );
   }
 
   goMap() {
     this.navCtrl.navigateForward('/G11/aparKing/map');
+  }
+
+  async updateUserGaragesWithPlan(planId: string) {
+    const userGarages = await this.restService
+      .getMyGarages()
+      .then((data) => data)
+      .catch((_) => []);
+    const nGarages = userGarages.length;
+
+    // if planId === 'FREE'
+    let garagesLimit = 1;
+    if (planId === 'NOBLE') {
+      garagesLimit = 3;
+    } else if (planId === 'KING') {
+      garagesLimit = 5;
+    }
+
+    if (nGarages > garagesLimit) {
+      // sort by creation_date reversed (new first)
+      userGarages.sort((a, b) => {
+        const dateA = new Date(a.creation_date);
+        const dateB = new Date(b.creation_date);
+        return dateB.getTime() - dateA.getTime();
+      });
+
+      while (userGarages.length > garagesLimit) {
+        const garage = userGarages.pop();
+        try {
+          if (garage) {
+            await this.restService.deleteGarage(garage.id);
+          } else {
+            throw new Error('Error al obtener el garaje');
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      const alert = await this.alertController.create({
+        header: 'Actualización de garajes',
+        message:
+          'Has superado el límite de garajes permitidos por el plan seleccionado. Se han conservado los últimos garajes creados permitidos por el nuevo plan seleccionado.',
+        buttons: ['OK'],
+      });
+      await alert.present();
+    }
   }
 }


### PR DESCRIPTION
Este fix implementa la comprobación del plan al que está suscrito el usuario. De tal forma que:

- Plan gratuito: sólo podrá crear 1 garaje.
- Plan noble: sólo podrá crear 3 garajes.
- Plan king: sólo podrá crear 5 garajes.

En el momento que un usuario intente crear más garajes que los permitidos por su plan, aparecerá una pantalla como la siguiente:

![image](https://github.com/Aparking/AparKing_Frontend/assets/128732971/64e21e45-ef10-44a7-9709-1e19d39283d7)

Además, se comprueba el número de garajes creados al cambiar el tipo de plan. Siguiendo la lógica anteriormente descrita, se eliminarán (por facilitar la operación con el backend y no tener información residual en la bd) los garajes del usuario hasta cumplir con las restricciones del plan. El orden de eliminación será desde el más antiguo hasta el más nuevo según la fecha de creación.