### PR TITLE
Añadir hora a la fecha de inicio y final de una reserva

### DIFF
--- a/src/app/components/rental/garage-availability-list-create/garage-availability-list-create.component.html
+++ b/src/app/components/rental/garage-availability-list-create/garage-availability-list-create.component.html
@@ -28,12 +28,12 @@
         <ion-item>
           <ion-label>Fecha de inicio</ion-label>
           <ion-text>{{
-            availability.start_date | date : "yyyy-MM-dd"
+            availability.start_date | date : "dd/MM/yyyy HH:mm"
           }}</ion-text>
         </ion-item>
         <ion-item>
           <ion-label>Fecha de fin</ion-label>
-          <ion-text>{{ availability.end_date | date : "yyyy-MM-dd" }}</ion-text>
+          <ion-text>{{ availability.end_date | date : "dd/MM/yyyy HH:mm" }}</ion-text>
         </ion-item>
         <ion-item>
           <ion-label>Estado</ion-label>
@@ -59,7 +59,7 @@
                 label-placement="floating"
                 label="Fecha de inicio"
                 formControlName="start_date"
-                type="date"
+                type="datetime-local"
               ></ion-input>
               <div class="error-container">
                 <app-error-message
@@ -83,7 +83,7 @@
                 label-placement="floating"
                 label="Fecha de fin"
                 formControlName="end_date"
-                type="date"
+                type="datetime-local"
               ></ion-input>
               <div class="error-container">
                 <app-error-message

--- a/src/app/components/rental/garage-book-create/garage-book-create.component.html
+++ b/src/app/components/rental/garage-book-create/garage-book-create.component.html
@@ -76,8 +76,8 @@
                 *ngFor="let availability of availabilities"
                 [value]="availability.id"
               >
-                {{ availability.start_date | date : "yyyy-MM-dd" }} -
-                {{ availability.end_date | date : "yyyy-MM-dd" }}
+                {{ availability.start_date | date : "dd/MM/yyyy HH:mm" }} -
+                {{ availability.end_date | date : "dd/MM/yyyy HH:mm" }}
               </ion-select-option>
             </ion-select>
           </ion-item>


### PR DESCRIPTION
He añadido la posibilidad de añadir la hora además de cambiar el formato en el que se mostraban las fechas, ya que estaba el formato americano y es lioso si la app está en español.
![image](https://github.com/Aparking/AparKing_Backend/assets/72879200/ae04e1ab-838c-4cd8-8eb1-57ec43b93197)
![image](https://github.com/Aparking/AparKing_Backend/assets/72879200/87ccaa5d-180f-474b-a794-1bcaa4ca879b)
